### PR TITLE
Fixed typo in --help

### DIFF
--- a/src/AnalysisPrograms/AnalyseLongRecordings/AnalyseLongRecordings.Arguments.cs
+++ b/src/AnalysisPrograms/AnalyseLongRecordings/AnalyseLongRecordings.Arguments.cs
@@ -67,7 +67,7 @@ AlignToMinute Options:
             public double? EndOffset { get; set; }
 
             [Option(
-                Description = "Allow advancing the start of the analysis to the nearest minute. A valid datetime must be available in the file name. Seed additional notes for options.",
+                Description = "Allow advancing the start of the analysis to the nearest minute. A valid datetime must be available in the file name. See additional notes for options.",
                 ShortName = "")]
             public TimeAlignment AlignToMinute { get; set; } = TimeAlignment.None;
 


### PR DESCRIPTION
Minor fix to correct a typo:

"seed" -> "see"

Fix #188